### PR TITLE
removed id in NewCluster

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -120,7 +120,7 @@ func Initialize(address string, useHTTPS bool, storage storage.Storage, splunk l
 	// clusters-related operations
 	// (handlers are implemented in the file cluster.go)
 	clientRouter.HandleFunc("/cluster", func(w http.ResponseWriter, r *http.Request) { getClusters(w, r, storage) }).Methods("GET")
-	clientRouter.HandleFunc("/cluster/{id:[0-9]+}/{name}", func(w http.ResponseWriter, r *http.Request) { newCluster(w, r, storage, splunk) }).Methods("POST")
+	clientRouter.HandleFunc("/cluster/{name}", func(w http.ResponseWriter, r *http.Request) { newCluster(w, r, storage, splunk) }).Methods("POST")
 	clientRouter.HandleFunc("/cluster/{id:[0-9]+}", func(w http.ResponseWriter, r *http.Request) { getClusterByID(w, r, storage) }).Methods("GET")
 	clientRouter.HandleFunc("/cluster/{id:[0-9]+}", func(w http.ResponseWriter, r *http.Request) { deleteCluster(w, r, storage, splunk) }).Methods("DELETE")
 	clientRouter.HandleFunc("/cluster/search", func(w http.ResponseWriter, r *http.Request) { searchCluster(w, r, storage) }).Methods("GET")


### PR DESCRIPTION
tested locally with insights-operator-cli
```
$ ./insights-operator-cli 
> add cluster 33de
Controller has been registered
> list clusters
List of clusters
   #   ID Name
   0   11 fw0GEVCkhz
   1   12 CFCxdn66vf
   2   13 LqDxUOm4fJ
   3   14 hNYI56SScu
   4   15 NwqGPonapW
   5   16 new
   6   17 LQ9Yp32t26
   7   18 WwJ9cERPM4
   8   19 TF1eH0BUJL
   9   20 nnqbUIJnL7
  10   21 sXy8C9fbok
  11   22 YTLXtGPlhW
  12   23 6YBrDNyupr
  13   24 FbP5s2moet
  14   25 svMtzB2STY
  15   26 Dxv8M3YWfc
  16   27 XV42DbFauB
  17   28 cluster
  18   29 b0NFRcbggf
  19   30 sb27LDCsoY
  20   31 33de
> 
```