### PR TITLE
fixed https in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Just run the executable file created by `go build`:
 ### HTTPS instead of HTTP
 
 Change the following lines in `config.toml`:
-- use_https=false
-- address=":4443"
+```
+use_https=true
+address=":4443"
+```
 
 Please note that the service (when run locally) use the self-signed certificate.
 You'd need to use `certs.pem` file on client side (curl, web browser etc.)


### PR DESCRIPTION
I think it's a typo and to use https it needs to be set to true, is it correct @tisnik ?