### PR TITLE
Use govalidator and gorilla/schema for validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.13
 
 require (
 	github.com/ZachtimusPrime/Go-Splunk-HTTP v0.0.0-20190909123348-f5369e72b8af
+	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.7.3
+	github.com/gorilla/schema v1.1.0
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mozillazg/request v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/ZachtimusPrime/Go-Splunk-HTTP v0.0.0-20190909123348-f5369e72b8af/go.m
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -48,6 +50,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/schema v1.1.0 h1:CamqUDOFUBqzrvxuz2vEwo8+SUdwsluFh7IlzJh30LY=
+github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -19,11 +19,13 @@ limitations under the License.
 package server
 
 import (
-	"github.com/gorilla/mux"
-	"github.com/redhatinsighs/insights-operator-controller/utils"
 	"log"
 	"net/http"
-	"strconv"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/gorilla/mux"
+	"github.com/redhatinsighs/insights-operator-controller/storage"
+	"github.com/redhatinsighs/insights-operator-controller/utils"
 )
 
 // GetClusters - read list of all clusters from database and return it to a client.
@@ -111,33 +113,65 @@ func (s Server) DeleteCluster(writer http.ResponseWriter, request *http.Request)
 
 // SearchCluster - search for a cluster specified by its ID or name.
 func (s Server) SearchCluster(writer http.ResponseWriter, request *http.Request) {
-	idParam, foundID := request.URL.Query()["id"]
-	nameParam, foundName := request.URL.Query()["name"]
+	var (
+		req     SearchClusterRequest
+		cluster storage.Cluster
+		err     error
+	)
+
+	err = utils.DecodeValidRequest(&req, SearchClusterTemplate, request.URL.Query())
+	if err != nil {
+		log.Println(err)
+		utils.SendError(writer, err.Error())
+		return
+	}
 
 	// either cluster id or its name needs to be specified
-	if foundID {
-		id, err := strconv.ParseInt(idParam[0], 10, 0)
-		if err != nil {
-			log.Println("Error reading and decoding cluster ID from query", err)
-			utils.SendError(writer, "Error reading and decoding cluster ID from query\n")
-		} else {
-			cluster, err := s.Storage.GetCluster(int(id))
-			if err != nil {
-				log.Println("Unable to read cluster from database", err)
-				utils.SendError(writer, err.Error())
-			} else {
-				utils.SendResponse(writer, utils.BuildOkResponseWithData("cluster", cluster))
-			}
-		}
-	} else if foundName {
-		cluster, err := s.Storage.GetClusterByName(nameParam[0])
-		if err != nil {
-			log.Println("Unable to read cluster from database", err)
-			utils.SendError(writer, err.Error())
-		} else {
-			utils.SendResponse(writer, utils.BuildOkResponseWithData("cluster", cluster))
-		}
+	if req.Id != 0 {
+		cluster, err = s.Storage.GetCluster(req.Id)
 	} else {
-		utils.SendError(writer, "Either cluster ID or name needs to be specified")
+		cluster, err = s.Storage.GetClusterByName(req.Name)
 	}
+	if err != nil {
+		log.Println("Unable to read cluster from database", err)
+		utils.SendError(writer, err.Error())
+		return
+	}
+
+	utils.SendResponse(writer, utils.BuildOkResponseWithData("cluster", cluster))
+}
+
+type SearchClusterRequest struct {
+	utils.Pagination
+	Id   int    `schema:"id"`
+	Name string `schema:"name"`
+}
+
+var SearchClusterTemplate = utils.MergeMaps(map[string]interface{}{
+	// all acceptable fields are listed
+	// case sensitive
+	"id":   "int~Error reading and decoding cluster ID from query",
+	"name": "",
+	"":     "oneOfIdOrName~Either cluster ID or name needs to be specified",
+}, utils.PaginationTemplate)
+
+// oneOfIdOrNameValidation validates that id or name is filled
+func oneOfIdOrNameValidation(i interface{}, context interface{}) bool {
+	// Tag oneOfIdOrName
+	v, ok := context.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// the int validation is done next by validator, we are just checking if its filled
+	if id, ok := v["id"].(string); ok && len(id) != 0 {
+		return true
+	}
+	if name, ok := v["name"].(string); ok && len(name) != 0 {
+		return true
+	}
+	return false
+}
+
+func init() {
+	govalidator.CustomTypeTagMap.Set("oneOfIdOrName", govalidator.CustomTypeValidator(oneOfIdOrNameValidation))
 }

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -127,8 +127,8 @@ func (s Server) SearchCluster(writer http.ResponseWriter, request *http.Request)
 	}
 
 	// either cluster id or its name needs to be specified
-	if req.Id != 0 {
-		cluster, err = s.Storage.GetCluster(req.Id)
+	if req.ID != 0 {
+		cluster, err = s.Storage.GetCluster(req.ID)
 	} else {
 		cluster, err = s.Storage.GetClusterByName(req.Name)
 	}
@@ -141,12 +141,14 @@ func (s Server) SearchCluster(writer http.ResponseWriter, request *http.Request)
 	utils.SendResponse(writer, utils.BuildOkResponseWithData("cluster", cluster))
 }
 
+// SearchClusterRequest defines type safe SearchCluster request
 type SearchClusterRequest struct {
 	utils.Pagination
-	Id   int    `schema:"id"`
+	ID   int    `schema:"id"`
 	Name string `schema:"name"`
 }
 
+// SearchClusterTemplate defines validation rules and messages for SearchCluster
 var SearchClusterTemplate = utils.MergeMaps(map[string]interface{}{
 	// all acceptable fields are listed
 	// case sensitive
@@ -155,8 +157,8 @@ var SearchClusterTemplate = utils.MergeMaps(map[string]interface{}{
 	"":     "oneOfIdOrName~Either cluster ID or name needs to be specified",
 }, utils.PaginationTemplate)
 
-// oneOfIdOrNameValidation validates that id or name is filled
-func oneOfIdOrNameValidation(i interface{}, context interface{}) bool {
+// oneOfIDOrNameValidation validates that id or name is filled
+func oneOfIDOrNameValidation(i interface{}, context interface{}) bool {
 	// Tag oneOfIdOrName
 	v, ok := context.(map[string]interface{})
 	if !ok {
@@ -173,5 +175,5 @@ func oneOfIdOrNameValidation(i interface{}, context interface{}) bool {
 }
 
 func init() {
-	govalidator.CustomTypeTagMap.Set("oneOfIdOrName", govalidator.CustomTypeValidator(oneOfIdOrNameValidation))
+	govalidator.CustomTypeTagMap.Set("oneOfIdOrName", govalidator.CustomTypeValidator(oneOfIDOrNameValidation))
 }

--- a/utils/maps.go
+++ b/utils/maps.go
@@ -1,0 +1,96 @@
+// Utils for working with maps
+
+/*
+Copyright © 2019, 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "net/url"
+
+// mergeMapsT merges multiple maps of various types, trying to convert them
+// srcs can be;
+// map[string]interface{} (for example body dedoded from json)
+// map[string][]string  (for example r.URL.Query() or r.Form (as url.Values))
+func mergeMapsT(srcs ...interface{}) map[string]interface{} {
+	input := make(map[string]interface{})
+	for _, srcm := range srcs {
+		var toMerge map[string]interface{}
+
+		switch v := srcm.(interface{}).(type) {
+		case map[string]interface{}:
+			toMerge = v
+
+		case map[string][]string:
+			toMerge = interMap(v)
+
+		case url.Values:
+			toMerge = interMap((map[string][]string)(v))
+
+		default:
+			panic("unknown type")
+		}
+
+		input = MergeMaps(input, toMerge)
+	}
+	return input
+}
+
+// stringsMap converts map[string]interface{} to flat map[string][]string
+// Main use case is convert already flat map[string][]string or map[string]string
+func stringsMap(m map[string]interface{}) map[string][]string {
+	sm := make(map[string][]string)
+	// add more types if needed
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			sm[k] = []string{s}
+		}
+		if s, ok := v.([]string); ok {
+			sm[k] = s
+		}
+		if s, ok := v.(map[string]interface{}); ok {
+			fm := stringsMap(s)
+			for kk, vv := range fm {
+				sm[kk] = vv
+			}
+		}
+	}
+	return sm
+}
+
+// interMap converts map from [string][]string to [string]interface{}
+// taking last value from many in []string if more exists
+func interMap(m map[string][]string) map[string]interface{} {
+	r := make(map[string]interface{})
+	for k, v := range m {
+		// use last provided value
+		if len(v) > 0 {
+			r[k] = v[len(v)-1]
+		}
+	}
+	return r
+}
+
+// MergeMaps Merges provided maps into one
+func MergeMaps(maps ...map[string]interface{}) map[string]interface{} {
+	r := make(map[string]interface{})
+
+	for _, m := range maps {
+		for k, v := range m {
+			r[k] = v
+		}
+	}
+	return r
+}

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -119,11 +119,13 @@ func MergeMaps(maps ...map[string]interface{}) map[string]interface{} {
 	return r
 }
 
+// Pagination defines type safe Pagination request components
 type Pagination struct {
 	Limit  int `schema:"limit" valid:"type(int)~Limit has to be a number"`
 	Offset int `schema:"offset" valid:"type(int)~Offset has to be a number"`
 }
 
+// PaginationTemplate contains validation for Pagination components
 var PaginationTemplate = map[string]interface{}{
 	"limit":  "int~Limit has to be a number",
 	"offset": "int~Offset has to be a number",

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -1,0 +1,130 @@
+// Utils for Http Rest Request validation and decoding
+
+/*
+Copyright © 2019, 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"net/url"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/gorilla/schema"
+)
+
+var decoder = schema.NewDecoder()
+
+// DecodeValidRequest validates input maps (From Query.URL, or decoded Json Body) against template and returns typed structure
+// srcs can be list of either map[string]interface{} or map[string][]string
+func DecodeValidRequest(dst interface{}, temp map[string]interface{}, srcs ...interface{}) error {
+	input := mergeMapsT(srcs...)
+	sm := stringsMap(input)
+	// add invalid key to force non keyed validator to run
+	input[""] = ""
+	// validate generic map to report correct type errors
+	_, err := govalidator.ValidateMap(input, temp)
+	if err != nil {
+		return err
+	}
+	// convert valid map to type safe struct
+	err = decoder.Decode(dst, sm)
+	return err
+}
+
+// mergeMapsT merges multiple maps of various types, trying to convert them
+// srcs can be;
+// map[string]interface{} (for example body dedoded from json)
+// map[string][]string  (for example r.URL.Query() or r.Form (as url.Values))
+func mergeMapsT(srcs ...interface{}) map[string]interface{} {
+	input := make(map[string]interface{})
+	for _, srcm := range srcs {
+		var toMerge map[string]interface{}
+
+		switch v := srcm.(interface{}).(type) {
+		case map[string]interface{}:
+			toMerge = v
+
+		case map[string][]string:
+			toMerge = interMap(v)
+
+		case url.Values:
+			toMerge = interMap((map[string][]string)(v))
+
+		default:
+			panic("unknown type")
+		}
+
+		input = MergeMaps(input, toMerge)
+	}
+	return input
+}
+
+// stringsMap converts map[string]interface{} to flat map[string][]string
+// Main use case is convert already flat map[string][]string or map[string]string
+func stringsMap(m map[string]interface{}) map[string][]string {
+	sm := make(map[string][]string)
+	// add more types if needed
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			sm[k] = []string{s}
+		}
+		if s, ok := v.([]string); ok {
+			sm[k] = s
+		}
+		if s, ok := v.(map[string]interface{}); ok {
+			fm := stringsMap(s)
+			for kk, vv := range fm {
+				sm[kk] = vv
+			}
+		}
+	}
+	return sm
+}
+
+// interMap converts map from [string][]string to [string]interface{}
+// taking last value from many in []string if more exists
+func interMap(m map[string][]string) map[string]interface{} {
+	r := make(map[string]interface{})
+	for k, v := range m {
+		// use last provided value
+		if len(v) > 0 {
+			r[k] = v[len(v)-1]
+		}
+	}
+	return r
+}
+
+// MergeMaps Merges provided maps into one
+func MergeMaps(maps ...map[string]interface{}) map[string]interface{} {
+	r := make(map[string]interface{})
+
+	for _, m := range maps {
+		for k, v := range m {
+			r[k] = v
+		}
+	}
+	return r
+}
+
+type Pagination struct {
+	Limit  int `schema:"limit" valid:"type(int)~Limit has to be a number"`
+	Offset int `schema:"offset" valid:"type(int)~Offset has to be a number"`
+}
+
+var PaginationTemplate = map[string]interface{}{
+	"limit":  "int~Limit has to be a number",
+	"offset": "int~Offset has to be a number",
+}

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -19,8 +19,6 @@ limitations under the License.
 package utils
 
 import (
-	"net/url"
-
 	"github.com/asaskevich/govalidator"
 	"github.com/gorilla/schema"
 )
@@ -42,81 +40,6 @@ func DecodeValidRequest(dst interface{}, temp map[string]interface{}, srcs ...in
 	// convert valid map to type safe struct
 	err = decoder.Decode(dst, sm)
 	return err
-}
-
-// mergeMapsT merges multiple maps of various types, trying to convert them
-// srcs can be;
-// map[string]interface{} (for example body dedoded from json)
-// map[string][]string  (for example r.URL.Query() or r.Form (as url.Values))
-func mergeMapsT(srcs ...interface{}) map[string]interface{} {
-	input := make(map[string]interface{})
-	for _, srcm := range srcs {
-		var toMerge map[string]interface{}
-
-		switch v := srcm.(interface{}).(type) {
-		case map[string]interface{}:
-			toMerge = v
-
-		case map[string][]string:
-			toMerge = interMap(v)
-
-		case url.Values:
-			toMerge = interMap((map[string][]string)(v))
-
-		default:
-			panic("unknown type")
-		}
-
-		input = MergeMaps(input, toMerge)
-	}
-	return input
-}
-
-// stringsMap converts map[string]interface{} to flat map[string][]string
-// Main use case is convert already flat map[string][]string or map[string]string
-func stringsMap(m map[string]interface{}) map[string][]string {
-	sm := make(map[string][]string)
-	// add more types if needed
-	for k, v := range m {
-		if s, ok := v.(string); ok {
-			sm[k] = []string{s}
-		}
-		if s, ok := v.([]string); ok {
-			sm[k] = s
-		}
-		if s, ok := v.(map[string]interface{}); ok {
-			fm := stringsMap(s)
-			for kk, vv := range fm {
-				sm[kk] = vv
-			}
-		}
-	}
-	return sm
-}
-
-// interMap converts map from [string][]string to [string]interface{}
-// taking last value from many in []string if more exists
-func interMap(m map[string][]string) map[string]interface{} {
-	r := make(map[string]interface{})
-	for k, v := range m {
-		// use last provided value
-		if len(v) > 0 {
-			r[k] = v[len(v)-1]
-		}
-	}
-	return r
-}
-
-// MergeMaps Merges provided maps into one
-func MergeMaps(maps ...map[string]interface{}) map[string]interface{} {
-	r := make(map[string]interface{})
-
-	for _, m := range maps {
-		for k, v := range m {
-			r[k] = v
-		}
-	}
-	return r
 }
 
 // Pagination defines type safe Pagination request components


### PR DESCRIPTION
# Description
The goal is make easier adding later the pagination (offset/limit) query arguments. This change is changing validation to use govalidator, which should make Rest methods later more concise.
The change is isolated to SearchCluster.

This is adding two golang libraries: asaskevich/govalidator and gorilla/schema. Otherwise code should run as before.

## Type of change

Please delete options that are not relevant.

- [x] Refactor (refactoring code, removing useless files)

## Testing steps

I have invoked curl to check combination with querying by id, name, without any (fail) and with invalid id (character) (fail). I used this command:
```
curl localhost:8080/api/v1/client/cluster/search?id=1
```