### PR TITLE
Make REST validation case insensitive

### DIFF
--- a/utils/maps.go
+++ b/utils/maps.go
@@ -20,6 +20,8 @@ package utils
 
 import "net/url"
 
+import "strings"
+
 // mergeMapsT merges multiple maps of various types, trying to convert them
 // srcs can be;
 // map[string]interface{} (for example body dedoded from json)
@@ -68,6 +70,16 @@ func stringsMap(m map[string]interface{}) map[string][]string {
 		}
 	}
 	return sm
+}
+
+// LowerCaseKeys returns new map with keys changed to lowercase
+func LowerCaseKeys(m map[string]interface{}) map[string]interface{} {
+	nm := map[string]interface{}{}
+
+	for k, v := range m {
+		nm[strings.ToLower(k)] = v
+	}
+	return nm
 }
 
 // interMap converts map from [string][]string to [string]interface{}

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -28,7 +28,7 @@ var decoder = schema.NewDecoder()
 // DecodeValidRequest validates input maps (From Query.URL, or decoded Json Body) against template and returns typed structure
 // srcs can be list of either map[string]interface{} or map[string][]string
 func DecodeValidRequest(dst interface{}, temp map[string]interface{}, srcs ...interface{}) error {
-	input := mergeMapsT(srcs...)
+	input := LowerCaseKeys(mergeMapsT(srcs...))
 	sm := stringsMap(input)
 	// add invalid key to force non keyed validator to run
 	input[""] = ""


### PR DESCRIPTION
# Description

I have found the validation using new validator is case sensitive, ie this didn't work:
```
curl 'http://localhost:8080/api/v1/client/cluster/search?ID=1'                                     
{"status":"all map keys has to be present in the validation map; got ID;Either cluster ID or name needs to be specified"}
```

Fixes # (issue)
I have converted the keys to lowercase before validation to fix this

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing steps
The command in description above passed.

