### PR TITLE
fix dockerize_postgres.sh database host error

### DIFF
--- a/local_storage/create_database_docker.sh
+++ b/local_storage/create_database_docker.sh
@@ -4,7 +4,10 @@ SUPERUSER=postgres
 SU_PASSWORD=postgres
 
 DATABASE=controller
-DB_SERVER=local socket  # default value; for readability sake
+
+# when host is not specified, the default behaviour is to automatically connect
+# to the correct Unix-like socket (directory was specified when PostgreSQL was built)
+DB_SERVER=
 
 USER=tester
 USER_PASSWORD=tester


### PR DESCRIPTION
# Description
There was an unnoticed bug that I let slip through - I got the following information from `psql --help`
```
...
Connection options:
  -h, --host=HOSTNAME      database server host or socket directory (default: "local socket")
  -p, --port=PORT          database server port (default: "5432")
  -U, --username=USERNAME  database user name (default: "postgres")
...
```
So, in `create_database_postgres.sh` I tried using `DB_SERVER=local socket` as a host not realizing it doesn't work the same for "connection strings"... When it encountered the variable, an error got thrown `line 7: socket: command not found` but the execution didn't stop for me, instead it connected to the correct unix socket without any problem, created a database and some data with no problems. I tested it in the PR https://github.com/RedHatInsights/insights-operator-controller/pull/126.
I tested the container in detached mode, so I didn't notice the error (my bad)

However @bond95 tried it and the execution stopped for him at that line. I changed it so that it doesn't throw the error and stop the execution.

Lesson learned: test containers in non-detached mode and look through the output closely 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing steps
Tested on mine and @bond95 machine. Works for both without any error thrown.
