### PR TITLE
Fixed issue #430

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -38,7 +38,7 @@
         "/client/cluster": {
             "x-temp": {
                 "summary": "Read list of all clusters from database and return it to a client",
-                "description": "",
+                "description": "Read list of all clusters from database and return it to a client",
                 "parameters": [],
                 "operationId": "getClusters",
                 "responses": {


### PR DESCRIPTION
# Description

No description found for endpoint `/organizations/{orgId}/clusters` and method `get` in OpenAPI specification

Fixes #430

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A