### PR TITLE
Add link to documentation generated for RedHatInsights/insights-operator-controller/server/testutils_test.go

### DIFF
--- a/docs/packages/server/testutils_test.html
+++ b/docs/packages/server/testutils_test.html
@@ -121,6 +121,14 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">server_test</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-controller/packages/server/testutils_test.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;bytes&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/RedHatInsights/insights-operator-controller/logging&#34;</div><div class="operator"></div>

--- a/server/testutils_test.go
+++ b/server/testutils_test.go
@@ -18,6 +18,9 @@ limitations under the License.
 
 package server_test
 
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-controller/packages/server/testutils_test.html
+
 import (
 	"bytes"
 	"github.com/RedHatInsights/insights-operator-controller/logging"


### PR DESCRIPTION
# Description

Add link to documentation generated for `RedHatInsights/insights-operator-controller/server/testutils_test.go`

Fixes #378

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

N/A