### PR TITLE
Add link to documentation generated for RedHatInsights/insights-operator-controller/server/trigger_test.go

### DIFF
--- a/docs/packages/server/trigger_test.html
+++ b/docs/packages/server/trigger_test.html
@@ -119,6 +119,14 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">server_test</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-controller/packages/server/trigger_test.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;net/http&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;testing&#34;</div><div class="operator"></div>

--- a/server/trigger_test.go
+++ b/server/trigger_test.go
@@ -16,6 +16,9 @@ limitations under the License.
 
 package server_test
 
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-controller/packages/server/trigger_test.html
+
 import (
 	"net/http"
 	"testing"


### PR DESCRIPTION
# Description

Add link to documentation generated for `RedHatInsights/insights-operator-controller/server/trigger_test.go`

Fixes #383

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

N/A