### PR TITLE
Bump-up Go version to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/insights-operator-controller
 
-go 1.14
+go 1.16
 
 require (
 	github.com/Masterminds/squirrel v1.2.0


### PR DESCRIPTION
# Description

Bump-up Go version to 1.16

Fixes #608

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
