### PR TITLE
Fixed issue #589

### DIFF
--- a/server/testutils_test.go
+++ b/server/testutils_test.go
@@ -1,7 +1,7 @@
 // Utilities for testing to avoid code repetition. File not in ./utils because
 // of cyclic imports
 /*
-Copyright © 2019, 2020 Red Hat, Inc.
+Copyright © 2019, 2020, 2021 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 	"github.com/RedHatInsights/insights-operator-controller/server"
 	"github.com/RedHatInsights/insights-operator-controller/storage"
 	"github.com/gorilla/mux"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -178,7 +178,7 @@ func CheckResponse(t *testing.T, rr *httptest.ResponseRecorder, expectedStatusCo
 	}
 
 	result := rr.Result()
-	body, _ := ioutil.ReadAll(result.Body)
+	body, _ := io.ReadAll(result.Body)
 
 	// body needs to be properly closed
 	defer func() {


### PR DESCRIPTION
# Description

Use `io.ReadAll` instead of `ioutils.ReadAll`

Fixes #589

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
